### PR TITLE
Fix shared RecipeChecker instance across multiple machines

### DIFF
--- a/common/src/main/java/fr/frinn/custommachinery/common/crafting/machine/CustomMachineRecipe.java
+++ b/common/src/main/java/fr/frinn/custommachinery/common/crafting/machine/CustomMachineRecipe.java
@@ -43,7 +43,6 @@ public class CustomMachineRecipe implements Recipe<Container>, IMachineRecipe {
     private MachineAppearance customAppearance;
     @Nullable
     private List<IGuiElement> customGuiElements;
-    private final Supplier<RecipeChecker<CustomMachineRecipe>> checker = Suppliers.memoize(() -> new RecipeChecker<>(this));
 
     public CustomMachineRecipe(ResourceLocation id, ResourceLocation machine, int time, List<IRequirement<?>> requirements, List<IRequirement<?>> jeiRequirements, int priority, int jeiPriority, boolean resetOnError, boolean hidden, @Nullable MachineAppearance appearance, List<IGuiElement> guiElements) {
         this.id = id;
@@ -161,10 +160,6 @@ public class CustomMachineRecipe implements Recipe<Container>, IMachineRecipe {
         });
         this.customGuiElements = List.copyOf(elements);
         return elements;
-    }
-
-    public RecipeChecker<CustomMachineRecipe> checker() {
-        return checker.get();
     }
 
     /** Vanilla Recipe Implementation **/

--- a/common/src/main/java/fr/frinn/custommachinery/common/crafting/machine/MachineRecipeFinder.java
+++ b/common/src/main/java/fr/frinn/custommachinery/common/crafting/machine/MachineRecipeFinder.java
@@ -34,7 +34,7 @@ public class MachineRecipeFinder {
                 .stream()
                 .filter(recipe -> tile.getMachine().getRecipeIds().contains(recipe.getMachineId()))
                 .sorted(Comparators.RECIPE_PRIORITY_COMPARATOR.reversed())
-                .map(CustomMachineRecipe::checker)
+                .map(RecipeChecker::new)
                 .toList();
         this.okToCheck = new ArrayList<>();
         this.recipeCheckCooldown = tile.getLevel().random.nextInt(this.baseCooldown);


### PR DESCRIPTION
Fixes an issue where RecipeChecker instance was shared across multiple machines. Each machine now creates its own checker instance, just as the original author did in the 1.21 branch